### PR TITLE
PLAT-6 Adding default .travis.yml for D8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - mysql -e 'create database drupal;'
 
   # Install drupal default profile
-  - drush --verbose site-install --db-url=mysql://root:@127.0.0.1/drupal --yes
+  - drush --verbose site-install cr --account-pass="admin" --db-url=mysql://root:@127.0.0.1/drupal --yes
 
   # Import config for our pseudo install
   #- drush --verbose config-import active --yes


### PR DESCRIPTION
http://jira.comicrelief.com/browse/PLAT-6 Adding Travis CI support D8. This will build the `cr` profile on every commit
