### PR TITLE
PLAT-26 Fix phing config-export

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,7 +26,7 @@
   <property name="app.password"           value="admin"                                            override="true" />
   <!-- Development variables. -->
   <property name="app.dev.modules"        value="config_devel default_content"   override="true" />
-  <property name="app.dev.config_modules" value="cr cr_article cr_teaser cr_default_content"               override="true" />
+  <property name="app.dev.config_modules" value="cr cr_article cr_default_content"               override="true" />
 
   <!-- Overrides -->
   <!-- <property name="php.sniff.dirs"       value="agov/modules/custom agov/themes agov/src" override="true" /> -->


### PR DESCRIPTION
http://jira.comicrelief.com/browse/PLAT-26 Use `phing config-export` to export all modules that define `yml` files
