### PR TITLE
PLAT-56 Added dep to CR profile so module is enabled on build

### DIFF
--- a/profiles/cr/cr.info.yml
+++ b/profiles/cr/cr.info.yml
@@ -46,6 +46,7 @@ dependencies:
   - metatag_open_graph
   - pathauto
   - youtube
+  - view_modes_display
 
   # Layout
   - inline_entity_form


### PR DESCRIPTION
Fixes https://jira.comicrelief.com/browse/PLAT-56

Missed the profile dep
## Deployment instructions
- No manual actions required for deployment
