### PR TITLE
Remove deployment instructions from PR template 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,3 @@ Fixes https://jira.comicrelief.com/browse/
 ## Changes proposed in this pull request
 - [ ] change...
 - [ ] change...
-
-## Deployment instructions
-* No manual actions required for deployment


### PR DESCRIPTION
…since we won't need that for the next months anyways
