### PR TITLE
PLAT-138 Remove 'tags' field from news article content type

### DIFF
--- a/profiles/cr/modules/custom/cr_article/cr_article.info.yml
+++ b/profiles/cr/modules/custom/cr_article/cr_article.info.yml
@@ -16,7 +16,6 @@ dependencies:
   - youtube
 
 config_devel:
-  - taxonomy.vocabulary.tags
   - node.type.article
   - core.entity_form_display.node.article.default
   - core.entity_view_display.node.article.default


### PR DESCRIPTION
### Ticket

Fixes https://jira.comicrelief.com/browse/PLAT-138
### Changes proposed in this pull request
- [ ] Remove 'tags' field from news article content type
### Notes:

Action spun off from closed PR: https://github.com/comicrelief/campaign/pull/124
No special deployment actions required
