### PR TITLE
Update to install symfony/dependency-injection 2.8.0

### DIFF
--- a/profiles/cr/tests/behat/composer.json
+++ b/profiles/cr/tests/behat/composer.json
@@ -5,7 +5,7 @@
     "sebastian/phpcpd": "^2.0",
     "phploc/phploc": "^3.0",
     "drupal/drupal-extension": "~3.0",
-    "symfony/dependency-injection": "2.7.6"
+    "symfony/dependency-injection": "2.8.0"
   },
   "require-dev": {
     "pantheon-systems/ci-scripts": "*",

--- a/profiles/cr/tests/behat/composer.lock
+++ b/profiles/cr/tests/behat/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "065c4bae9d77461152dc05f2b1b7fdec",
-    "content-hash": "dede228adea77928a427d12367d40b33",
+    "hash": "c30ec95265261b2e879e260be16f6c08",
+    "content-hash": "d8e57c7ed044883548fb13caab8b8c5b",
     "packages": [
         {
             "name": "behat/behat",
@@ -1667,16 +1667,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847"
+                "reference": "1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/af284e795ec8a08c80d1fc47518fd23004b89847",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4",
+                "reference": "1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4",
                 "shasum": ""
             },
             "require": {
@@ -1686,9 +1686,9 @@
                 "symfony/expression-language": "<2.6"
             },
             "require-dev": {
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.6",
-                "symfony/yaml": "~2.1"
+                "symfony/config": "~2.2|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/yaml": "~2.1|~3.0.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -1698,13 +1698,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1722,7 +1725,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-27 15:38:06"
+            "time": "2015-11-30 06:56:28"
         },
         {
             "name": "symfony/dom-crawler",


### PR DESCRIPTION
Fixes https://jira.comicrelief.com/browse/
## Changes proposed in this pull request
- [ ] Fixes symfony/dependency-injection to 2.8.0 to match the new drupal core
