### PR TITLE
PLAT-334 Do not use bundler or gems on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ before_install:
 install:
   - drupal-ti install
   - drupal-ti --include profiles/cr/tests/drupal_ti/scripts/before_install.sh
-  - phing build:prepare
+  - phing build:prepare:travis
 
 before_script:
   # Check code quality

--- a/profiles/cr/common.xml
+++ b/profiles/cr/common.xml
@@ -26,6 +26,10 @@
           description="Build all project dependencies. (gems, composer)">
     <exec logoutput="true" passthru="true" command="composer install --no-progress --prefer-dist"/>
   </target>
+  <target name="build:prepare:travis" depends="test:composer:install"
+          description="Build all project dependencies using composer but without gems, for Travis CI">
+    <exec logoutput="true" passthru="true" command="composer install --no-progress --prefer-dist"/>
+  </target>
   <!-- Front-end -->
   <target name="grunt:build" description="Generate all compiled Sass and JS files.">
     <exec dir="${app.profile.dir}" logoutput="true" passthru="true"


### PR DESCRIPTION
Fixes https://jira.comicrelief.com/browse/PLAT-334

See also:
- https://github.com/comicrelief/campaign/pull/352

This change can be undone once we sort out the real issues as described in https://jira.comicrelief.com/browse/PLAT-334 but since we don't need bundler on Travis for tests let's remove this for now.

Follow-up work (i.e. fixing bundler on Travis) needs to happen in https://github.com/comicrelief/campaign/pull/356
