### PR TITLE
PLAT-489 fullwidth mobile button option

### DIFF
--- a/profiles/cr/themes/custom/campaign_base/sass/components/buttons/_buttons.scss
+++ b/profiles/cr/themes/custom/campaign_base/sass/components/buttons/_buttons.scss
@@ -20,6 +20,7 @@
 // :focus - Button focus state
 // .btn--fixed-width - Min width button, expands to width of container but min width of 290px
 // .btn--lg - Large buttons
+// .btn--full-width - Full-width button on SM breakpoint only
 //
 // Style guide: Buttons
 
@@ -58,7 +59,6 @@
     }
   }
 }
-
 
 /* Process $buttonList colour variations through our btn-variation mixin. */
 @each $button in $buttonList {

--- a/profiles/cr/themes/custom/campaign_base/sass/components/buttons/buttons.hbs
+++ b/profiles/cr/themes/custom/campaign_base/sass/components/buttons/buttons.hbs
@@ -13,5 +13,6 @@
     <a href="btn btn--red {{modifier_class}}" href="#"></a>
     <a href="btn btn--red {{modifier_class}}" href="#"></a>
     <a href="btn btn--red {{modifier_class}}" href="#"></a>
+    <a href="btn btn--red {{modifier_class}}" href="#"></a>
   </p>
 </div>


### PR DESCRIPTION
https://jira.comicrelief.com/browse/PLAT-489#comment-74307

**Notes**:
2 sibling buttons (that sit side-by-side, wrapped by a P tag) will need to remain full-width SM. This is due to display inline-block limitations, and display block will naturally go full-width without a fixed width supplied.

As we can't target them in CSS alone, we'd just need to add the new 'btn--full-width' class to them too in order to make everything groovy again, or else this happens on the larger side of SM breakpoint 

https://jira.comicrelief.com/secure/attachment/33323/Screen%20Shot%202016-11-11%20at%2012.17.12.png