### PR TITLE
Test PR from Fork -- disabling cr_default_content

### DIFF
--- a/cr/cr.info.yml
+++ b/cr/cr.info.yml
@@ -109,7 +109,7 @@ dependencies:
 
   # Default content; will be moved out of the profile at some point
   - simple_sitemap
-  - cr_default_content
+  #- cr_default_content
 
   # Because cr_landing_pages has content dependencies this needs to be loaded after
   - cr_search


### PR DESCRIPTION
Fixes https://jira.comicrelief.com/browse/

## Observations

* Platform.sh env is built from PRs made from forks -- review if this is what we want
* No Travis Tests are run, we need the opposite. Check also limitations in Travis for when we open-source
