### PR TITLE
PLAT-767: js update to hide searchbox too

### DIFF
--- a/cr/themes/custom/campaign_base/scripts/custom/campaign_base.js
+++ b/cr/themes/custom/campaign_base/scripts/custom/campaign_base.js
@@ -47,6 +47,7 @@
         $('button.feature-nav-toggle.is-active').removeClass('is-active');
         $('.header__inner-wrapper nav.navigation.show, .search-overlay.show, .block--cr-email-signup--head').removeClass('show');
         $('.meta-icons__esu-toggle.active, meta-icons__magnify.active').removeClass('active');
+        $('.search-overlay.search-on').removeClass('search-on');
       }
     });
     


### PR DESCRIPTION
Just an additional selector to hide the searchbox itself, rather than the overlay; missing piece of work from PLAT-762