### PR TITLE
PLAT-773 Add blazy and responsive image styles to Article thumbnails

### DIFF
--- a/cr/cr.info.yml
+++ b/cr/cr.info.yml
@@ -64,6 +64,7 @@ dependencies:
   - field_group
   - twig_tweak
   - blazy
+  - video_embed_media
 
   # Layout
   - inline_entity_form

--- a/cr/cr.install
+++ b/cr/cr.install
@@ -263,5 +263,12 @@ function cr_update_8029() {
  * Install better_exposed_filters & cr_image
  */
 function cr_update_8030() {
-  installer()->install(['better_exposed_filters'], ['cr_image']);
+  installer()->install(['better_exposed_filters', 'cr_image']);
+}
+
+/**
+ * Install video_embed_media
+ */
+function cr_update_8031() {
+  installer()->install(['video_embed_media']);
 }


### PR DESCRIPTION
Fixes https://jira.comicrelief.com/browse/PLAT-773

## Changes proposed in this PR

- [x] enable video media embed module
- [ ] alter the video media bundle to use video embed field and configure blazy and responsive image styles for the relevant view modes
- [ ] update the field and view displays in Articles
