### PR TITLE
#886 - Implement colour service

### DIFF
--- a/modules/cr_single_msg/cr_single_msg.module
+++ b/modules/cr_single_msg/cr_single_msg.module
@@ -14,24 +14,7 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
  * @see options_allowed_values()
  */
 function cr_single_msg_field_single_msg_bg(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL) {
-  $values = [
-    'bg--white' => t('White'),
-    'bg--black' => t('Black'),
-    'bg--red' => t('Red'),
-    'bg--blue' => t('Blue'),
-    'bg--yellow' => t('Yellow'),
-    'bg--green' => t('Green'),
-    'bg--teal' => t('Teal'),
-    'bg--royal-blue' => t('Royal blue'),
-    'bg--pink' => t('Pink'),
-    'bg--purple' => t('Purple'),
-    'bg--jasper-grey' => t('Jasper grey'),
-    'bg--gainsboro-grey' => t('Gainsboro grey'),
-    'bg--light-grey' => t('Light grey'),
-    'bg--smoke-grey' => t('Smoke grey'),
-    'bg--dark-blue' => t('Dark blue'),
-  ];
-  return $values;
+  return \Drupal::service('cr_single_msg.color_service')->get();
 }
 
 /**
@@ -40,24 +23,7 @@ function cr_single_msg_field_single_msg_bg(FieldStorageDefinitionInterface $defi
  * @see options_allowed_values()
  */
 function cr_single_msg_field_single_msg_body_bg_colour(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL) {
-  $values = [
-    'bg--white' => t('White'),
-    'bg--black' => t('Black'),
-    'bg--red' => t('Red'),
-    'bg--blue' => t('Blue'),
-    'bg--yellow' => t('Yellow'),
-    'bg--green' => t('Green'),
-    'bg--teal' => t('Teal'),
-    'bg--royal-blue' => t('Royal blue'),
-    'bg--pink' => t('Pink'),
-    'bg--purple' => t('Purple'),
-    'bg--jasper-grey' => t('Jasper grey'),
-    'bg--gainsboro-grey' => t('Gainsboro grey'),
-    'bg--light-grey' => t('Light grey'),
-    'bg--smoke-grey' => t('Smoke grey'),
-    'bg--dark-blue' => t('Dark blue'),
-  ];
-  return $values;
+    return \Drupal::service('cr_single_msg.color_service')->get();
 }
 
 /**

--- a/modules/cr_single_msg/cr_single_msg.services.yml
+++ b/modules/cr_single_msg/cr_single_msg.services.yml
@@ -1,0 +1,5 @@
+services:
+  cr_single_msg.color_service:
+    class: Drupal\cr_single_msg\Service\ColourService
+    arguments:
+      - '@string_translation'

--- a/modules/cr_single_msg/src/Service/ColourService.php
+++ b/modules/cr_single_msg/src/Service/ColourService.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\cr_single_msg\Service;
+
+use Drupal\Core\StringTranslation\TranslationManager;
+
+/**
+ * Class ColourService
+ * @package Drupal\cr_single_msg\Service
+ */
+class ColourService
+{
+
+    /**
+     * @var TranslationManager
+     */
+    private $translationManager;
+
+    /**
+     * ColourService constructor.
+     * @param TranslationManager $translationManager
+     */
+    public function __construct(TranslationManager $translationManager)
+    {
+        $this->translationManager = $translationManager;
+    }
+
+    /**
+     * Get an array of available colours.
+     * @return array
+     */
+    public function get()
+    {
+        return [
+            'bg--white' => $this->translationManager->translate('White'),
+            'bg--black' => $this->translationManager->translate('Black'),
+            'bg--red' => $this->translationManager->translate('Red'),
+            'bg--blue' => $this->translationManager->translate('Blue'),
+            'bg--yellow' => $this->translationManager->translate('Yellow'),
+            'bg--green' => $this->translationManager->translate('Green'),
+            'bg--teal' => $this->translationManager->translate('Teal'),
+            'bg--royal-blue' => $this->translationManager->translate('Royal blue'),
+            'bg--pink' => $this->translationManager->translate('Pink'),
+            'bg--purple' => $this->translationManager->translate('Purple'),
+            'bg--jasper-grey' => $this->translationManager->translate('Jasper grey'),
+            'bg--gainsboro-grey' => $this->translationManager->translate('Gainsboro grey'),
+            'bg--light-grey' => $this->translationManager->translate('Light grey'),
+            'bg--smoke-grey' => $this->translationManager->translate('Smoke grey'),
+            'bg--dark-blue' => $this->translationManager->translate('Dark blue'),
+        ];
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/comicrelief/campaign/issues/886

## Changes proposed in this PR

- This pull request abstracts colour definitions for the cr_single_msg module into a service. This is to allow this service to be more easily overridden in child themes, therefore allowing for child themes to implement there own colour choices.
