### PR TITLE
863 - Fix issue with field not being allowed in twig due to missing #…

### DIFF
--- a/modules/cr_feature_articles/cr_feature_articles.module
+++ b/modules/cr_feature_articles/cr_feature_articles.module
@@ -32,6 +32,5 @@ function cr_feature_articles_preprocess_ds_entity_view(array &$variables) {
       ->getRouteParameters()['taxonomy_term'];
     $variables['content']['articles'] = \Drupal::service('cr.feature_articles.taxonomy_service')
       ->getArticleNodesByTermId($tid);
-    $variables['content']['background_colour_class'] = $variables['content']['field_feature_articles_bg']['#items'][0]->getValue()['value'];
   }
 }

--- a/themes/custom/campaign_base/templates/components/feature-articles/ds-reset--paragraph-feature-articles.html.twig
+++ b/themes/custom/campaign_base/templates/components/feature-articles/ds-reset--paragraph-feature-articles.html.twig
@@ -1,7 +1,7 @@
 {%
 set classes = [
     'paragraph',
-    content.background_colour_class
+    content.field_feature_articles_bg['#items'][0].value
 ]
 %}
 {% set title_hidden = field_feature_articles_titlehide['#items'][0].value ? 'visuallyhidden' : '' %}


### PR DESCRIPTION
Twig does not allow items to be introduced in hooks that do not include type. Move field to be referenced in twig and remove from hook.