### PR TITLE
1042 - Change array structure of news view filter

### DIFF
--- a/modules/cr_article/src/Service/ArticleService.php
+++ b/modules/cr_article/src/Service/ArticleService.php
@@ -55,9 +55,6 @@ class ArticleService {
       throw new \Exception('Article type can only be news or press release');
     }
 
-    // Define the results array.
-    $results = array('All' => $this->translationManager->translate('All'));
-
     // Define query to get taxonomies on articles by type.
     $query = \Drupal::database()->select('taxonomy_term_field_data', 'term');
     $query->fields('term', ['tid', 'name']);
@@ -70,6 +67,8 @@ class ArticleService {
     $query->condition('field_data.status', '1');
     $query->groupBy('term.tid, term.name');
 
+    // Define the results array.
+    $results = array();
     foreach ($query->execute()->fetchAllAssoc('tid') as $item) {
       $results[$item->tid] = $item->name;
     }
@@ -77,6 +76,6 @@ class ArticleService {
     // Sort the array by value.
     asort($results);
 
-    return $results;
+    return array('All' => $this->translationManager->translate('All')) + $results;
   }
 }

--- a/modules/cr_article/src/Service/ArticleService.php
+++ b/modules/cr_article/src/Service/ArticleService.php
@@ -68,7 +68,7 @@ class ArticleService {
     $query->groupBy('term.tid, term.name');
 
     // Define the results array.
-    $results = array();
+    $results = [];
     foreach ($query->execute()->fetchAllAssoc('tid') as $item) {
       $results[$item->tid] = $item->name;
     }
@@ -76,6 +76,6 @@ class ArticleService {
     // Sort the array by value.
     asort($results);
 
-    return array('All' => $this->translationManager->translate('All')) + $results;
+    return ['All' => $this->translationManager->translate('All')] + $results;
   }
 }


### PR DESCRIPTION
Fixes #1042.

## Changes proposed in this PR

- Changes the way that the results array is created for the news and press releases views filter, so that the 'All' option is always the first item in the array, and therefore the first item in the list.
