### PR TITLE
QA test environment for nav

### DIFF
--- a/themes/custom/campaign_base/package.json
+++ b/themes/custom/campaign_base/package.json
@@ -2,7 +2,7 @@
   "name": "Campaign_base",
   "version": "1.0.0",
   "dependencies": {
-    "@comicrelief/pattern-lab": "^5.3.2",
+    "@comicrelief/pattern-lab": "^5.3.5",
     "async": "^2.4.0",
     "blazy": "1.8.2",
     "fs-extra": "^3.0.1",

--- a/themes/custom/campaign_base/package.json
+++ b/themes/custom/campaign_base/package.json
@@ -2,7 +2,7 @@
   "name": "Campaign_base",
   "version": "1.0.0",
   "dependencies": {
-    "@comicrelief/pattern-lab": "^5.1.7",
+    "@comicrelief/pattern-lab": "^5.3.2",
     "async": "^2.4.0",
     "blazy": "1.8.2",
     "fs-extra": "^3.0.1",

--- a/themes/custom/campaign_base/sass/styles.scss
+++ b/themes/custom/campaign_base/sass/styles.scss
@@ -7,3 +7,5 @@ $image-path: "/profiles/contrib/cr/themes/custom/campaign_base/images/patternlab
 @import "@comicrelief/pattern-lab/sass/base/_variables";
 @import "@comicrelief/pattern-lab/sass/base/_core";
 @import "@comicrelief/pattern-lab/sass/base/_components";
+
+//test change do not merge me :) 


### PR DESCRIPTION
**Test notes:**

Default navigation:
- Has all items inline in the header from the desktop-nav breakpoint on (1150px).
- The hamburger menu button is shown instead on smaller screen sizes.
- On desktop-nav breakpoint sub-items are shown on hover on the menu-items.
- On smaller screen sizes the sub-items appear on click on the menu-item.
- If a menu-item doesn't have sub-items the menu-item itself should follow the link on click.
- Check if the meta icons still appear properly and the interaction with them still works.

Feature navigation can be enabled by enabling the cr_navigation module


