### PR TITLE
Code snippet to aid with tooltip positioning and more

### DIFF
--- a/themes/custom/campaign_base/scripts/custom/campaign_base.js
+++ b/themes/custom/campaign_base/scripts/custom/campaign_base.js
@@ -146,5 +146,15 @@
         $('body').addClass('crNavTooltips');
       },
     });
+
+    // Helper snippet as the cookie banner module doesn't provide a 'state' we can use for any affected styling
+    setTimeout(function(){
+     // Add our active class if the banner is present
+      $('body > .cc_banner-wrapper').length ? $('body').addClass('cc-banner--visible') : null ;
+      // Add a button click handler (if it's) to remove the active class
+      $('.cc_banner-wrapper a.btn').on('click', function(){
+        $('body').removeClass('cc-banner--visible');
+      });
+    }, 1500);
   })
 })(jQuery, Drupal);


### PR DESCRIPTION
Fixes #1088

As the cookie banner module is a contrib module, we're unfortunately not easily able to extend it to add in this 'active' state, something required by the front-end to solve a few bugs related to the offset the banner produces when it's down. 

I've tested this setTimeOut against a throttled 'regular 3G' and 'good 2G' connection speed and it's long enough without effecting the UX perspective.