### PR TITLE
Adding jQuery UI patch back in

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "extra": {
         "patches": {
             "drupal/core": {
+                "See https://github.com/comicrelief/campaign/issues/1252": "https://gist.githubusercontent.com/adamclark-dev/f92fadd817aa3d45bc4aea18c566cd82/raw/11a65c7197f91aa77a6a220d0ff71d995dc6e428/drupal_8.4_form_reset.patch",
                 "See https://github.com/comicrelief/campaign/pull/252": "https://gist.githubusercontent.com/pvhee/14801e0f82e06f51cb0d88b9d400cbd6/raw/253f1c1e516eb24650a91d343c56a5aeb6a0ca43/PLAT-235_paragraph_constraint_violation.patch",
                 "See https://www.drupal.org/node/2911749": "https://www.drupal.org/files/issues/fix_ckeditor_styles_dropdown-2911749-17.patch"
             },


### PR DESCRIPTION
Type: patch

Fixes #1407 

## Changes proposed in this PR

- Reinstates the jQuery UI related patch that seemed to not make it to master