### PR TITLE
1480: Update views_ajax_history module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,9 +77,6 @@
             },
             "drupal/video_embed_field": {
                 "see https://www.drupal.org/project/video_embed_field/issues/2913598": "https://www.drupal.org/files/issues/2018-05-14/video_embed_field-title_attribute-2913598-21-8.x-2.x.patch"
-            },
-            "drupal/views_ajax_history": {
-                "see https://www.drupal.org/node/2835957": "https://www.drupal.org/files/issues/second_ajax_call-2835957-3.patch"
             }
         },
         "installer-paths": {
@@ -164,7 +161,7 @@
         "drupal/view_mode": "1.x-dev",
         "drupal/view_modes_display": "1.0",
         "drupal/view_unpublished": "1.0-alpha1",
-        "drupal/views_ajax_history": "1.x-dev",
+        "drupal/views_ajax_history": "1.0",
         "drush/drush": "9.3.0",
         "mouf/nodejs-installer": "~1.0",
         "php-amqplib/php-amqplib": "2.7.2",


### PR DESCRIPTION
Type: patch

Fixes #

## Changes proposed in this PR

- Update views_ajax_history module to official release: 1.0 version
- Avoid error while `composer install`:
`
- Installing drupal/views_ajax_history (dev-1.x bea2456): Cloning bea2456b51 from cache
      - Applying patches for drupal/views_ajax_history
        https://www.drupal.org/files/issues/second_ajax_call-2835957-3.patch (see https://www.drupal.org/node/2835957)
       Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/second_ajax_call-2835957-3.patch
`
